### PR TITLE
Fix petsc build logs. Update version

### DIFF
--- a/build_scripts/build_petsc.sh
+++ b/build_scripts/build_petsc.sh
@@ -1,4 +1,5 @@
-#!/bin/sh                                                                                                                                                                                                                                    
+#!/bin/sh
+
 set -e # Fail on first error
 
 export PETSC_VERSION=$1
@@ -9,7 +10,7 @@ mkdir -p ${UBCESLAB_SWENV_PREFIX:?undefined}/sourcesdir/petsc
 
 (cd $UBCESLAB_SWENV_PREFIX/sourcesdir/petsc
 if [ ! -f petsc-lite-$PETSC_VERSION.tar.gz  ]; then
-  wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-$PETSC_VERSION.tar.gz 
+  wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-$PETSC_VERSION.tar.gz
 fi
 )
 
@@ -57,8 +58,8 @@ make clean
 rm build_cmd_success
 
 make install
-mv configure.log $PETSC_INSTALL_DIR
-mv make.log $PETSC_INSTALL_DIR
+mv $PETSC_ARCH/lib/petsc/conf/configure.log $PETSC_INSTALL_DIR
+mv $PETSC_ARCH/lib/petsc/conf/make.log $PETSC_INSTALL_DIR
 
 # Build opt version
 export PETSC_INSTALL_DIR=$PETSC_PREFIX/opt
@@ -92,8 +93,8 @@ make clean
 rm build_cmd_success
 
 make install
-mv configure.log $PETSC_INSTALL_DIR
-mv make.log $PETSC_INSTALL_DIR
+mv $PETSC_ARCH/lib/petsc/conf/configure.log $PETSC_INSTALL_DIR
+mv $PETSC_ARCH/lib/petsc/conf/make.log $PETSC_INSTALL_DIR
 
 cd $UBCESLAB_SWENV_PREFIX
 rm -rf $BUILDDIR || true

--- a/build_scripts/build_petsc_version.sh
+++ b/build_scripts/build_petsc_version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-PETSC_VERSION=3.8.3
+PETSC_VERSION=3.9.3
 
 ./build_petsc.sh $PETSC_VERSION


### PR DESCRIPTION
Looks like we weren't copying the configure and make logs from the right location before.
Basically this PR fixes that and updates us to the latest version.